### PR TITLE
Add GetSections method 

### DIFF
--- a/uci_test.go
+++ b/uci_test.go
@@ -84,3 +84,17 @@ func TestWriteConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSections(t *testing.T) {
+	assert := assert.New(t)
+
+	r := NewTree("testdata")
+
+	names, exists := r.GetSections("system", "system")
+	assert.True(exists)
+	assert.ElementsMatch(names, []string{"@system[1]"})
+
+	names, exists = r.GetSections("system", "timeserver")
+	assert.True(exists)
+	assert.ElementsMatch(names, []string{"ntp"})
+}


### PR DESCRIPTION
This PR adds a `GetSections` method which returns a list of section names for a given config,
enabling the user to iterate over all sections of a config file.
It also contains a simple test for the method.

Admittedly this may not be the most elegant solution for this,
however it covers a quite a few basic usescases, (in my specific case iterating over all network interface sections,)  and it works well with the rest of the API.

Additionally this PR 'fixes' `ensureConfigLoaded` which always returns false if the config was not loaded beforehand. 
It returns loaded, which is false if the config has been loaded successfully within  `ensureConfigLoaded`.
I'm not sure this behaviour is intentional, but as far as I can tell from other calls to the method, it should only return false if the config file can not be accessed.
The test pass either way, so at least the fix does not seem to break anything.