### PR TITLE
Fixed error propagation in Commit()

### DIFF
--- a/uci.go
+++ b/uci.go
@@ -115,7 +115,10 @@ func (t *tree) Commit() error {
 		if !config.tainted {
 			continue
 		}
-		t.saveConfig(config)
+		err := t.saveConfig(config)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
First fix for #4.

It solves the immediate problem I have now.

However you might want to implement something a little more sophisticated in the long run.
This solution stops to write configs on the first error, which may result in an inconsistent state.
E.g. the firewall config is already written and the network config fails.
In this case the interface names might no longer match between the two.
Since the function is called `Commit()` users might expect to behave a little more transactional, 
either writing every change or none at all.
This would either require extensive checks prior to writing the first file, or some form of rollback mechanism.
Unfortunately I don't have the time to work on a better solution at this point.

