### PR TITLE
accept comments

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -149,6 +149,19 @@ func (l *lexer) acceptRun(valid string) {
 	l.backup()
 }
 
+// acceptComment consumes a line comment starting with # until eol or eof.
+func (l *lexer) acceptComment() {
+	if l.next() == '#' {
+		for {
+			r := l.next()
+			if r == '\n' || r == eof {
+				break
+			}
+		}
+	}
+	l.backup()
+}
+
 // acceptIdent consumes an UCI identifier [-_a-zA-Z0-9].
 func (l *lexer) acceptIdent() {
 	for {
@@ -189,6 +202,7 @@ func (l *lexer) rest() string {
 func lexKeyword(l *lexer) stateFn {
 	for {
 		l.acceptRun(" \t\n")
+		l.acceptComment()
 		l.ignore()
 		switch curr := l.rest(); {
 		case strings.HasPrefix(curr, string(kwPackage)):
@@ -321,7 +335,7 @@ Loop:
 			fallthrough
 		case eof:
 			return l.errorf("unterminated unquoted string")
-		case '\n':
+		case ' ', '\n':
 			break Loop
 		}
 	}

--- a/test_test.go
+++ b/test_test.go
@@ -84,6 +84,16 @@ config wifi-iface wifi0
 	option mode 'ap'
 `
 
+const tcComment = `
+# heading
+config foo
+	option opt1 1
+	# option opt1 2
+	option opt2 3 # baa
+	option opt3 hello
+# eof
+`
+
 var lexerTests = []struct {
 	name, input string
 	expected    []item
@@ -133,6 +143,12 @@ var lexerTests = []struct {
 		itemConfig.mk("config"), itemIdent.mk("wifi-iface"), itemString.mk("wifi0"),
 		itemOption.mk("option"), itemIdent.mk("device"), itemString.mk("wl0"),
 		itemOption.mk("option"), itemIdent.mk("mode"), itemString.mk("ap"),
+	}},
+	{"commented", tcComment, []item{
+		itemConfig.mk("config"), itemIdent.mk("foo"), // unnamed
+		itemOption.mk("option"), itemIdent.mk("opt1"), itemString.mk("1"),
+		itemOption.mk("option"), itemIdent.mk("opt2"), itemString.mk("3"),
+		itemOption.mk("option"), itemIdent.mk("opt3"), itemString.mk("hello"),
 	}},
 }
 


### PR DESCRIPTION
Ignore comments in uci config files rather than erroring out on them. This is roughly based on the test case by the original libuci project <https://git.openwrt.org/?p=project/uci.git;a=blob;f=test/references/get_multiline.data;h=bacb80438ee550a5170122c7f94a080ef9779492;hb=HEAD>