### PR TITLE
Add GetLast Function

### DIFF
--- a/convenience.go
+++ b/convenience.go
@@ -31,6 +31,11 @@ func Get(config, section, option string) ([]string, bool) {
 	return defaultTree.Get(config, section, option)
 }
 
+// GetLast delegates to the default tree. See Tree for details.
+func GetLast(config, section, option string) (string, bool) {
+	return defaultTree.GetLast(config, section, option)
+}
+
 // GetBool delegates to the default tree. See Tree for details.
 func GetBool(config, section, option string) (bool, bool) {
 	return defaultTree.GetBool(config, section, option)

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -40,6 +40,11 @@ func (m *mockTree) Get(config, section, option string) ([]string, bool) {
 	return []string{args.String(0)}, args.Bool(1)
 }
 
+func (m *mockTree) GetLast(config, section, option string) (string, bool) {
+	args := m.Called(config, section, option)
+	return args.String(0), args.Bool(1)
+}
+
 func (m *mockTree) GetBool(config, section, option string) (bool, bool) {
 	args := m.Called(config, section, option)
 	return args.Bool(0), args.Bool(1)
@@ -110,6 +115,16 @@ func TestConvenienceGet(t *testing.T) {
 	list, ok := Get("foo", "bar", "opt")
 	assert.True(ok)
 	assert.EqualValues([]string{"ok"}, list)
+	m.AssertExpectations(t)
+}
+
+func TestConvenienceGetLast(t *testing.T) {
+	assert := assert.New(t)
+	m := defaultTree.(*mockTree)
+	m.On("GetLast", "foo", "bar", "opt").Return("ok", true)
+	list, ok := GetLast("foo", "bar", "opt")
+	assert.True(ok)
+	assert.EqualValues("ok", list)
 	m.AssertExpectations(t)
 }
 

--- a/uci.go
+++ b/uci.go
@@ -43,7 +43,12 @@ type Tree interface {
 	// within exists.
 	Get(config, section, option string) ([]string, bool)
 
-	// GetBool works the same way as Get does but interprets the last
+	// GetLast retrieves the last value that was defined for a fully
+	// qualified option, and a boolean indicating whether the config file,
+	// config section and the option exists.
+	GetLast(config, section, option string) (string, bool)
+
+	// GetBool works the same way as GetLast does but interprets the last
 	// specified value as a boolean.  If the found value can't be
 	// interpreted as either true or false, it will return nil and false.
 	GetBool(config, section, option string) (bool, bool)
@@ -169,13 +174,21 @@ func (t *tree) Get(config, section, option string) ([]string, bool) {
 	return t.lookupValues(config, section, option)
 }
 
-func (t *tree) GetBool(config, section, option string) (bool, bool) {
+func (t *tree) GetLast(config, section, option string) (string, bool) {
 	vals, ok := t.Get(config, section, option)
 	if !ok || len(vals) == 0 {
-		return false, false
+		return "", false
 	}
 
-	switch vals[len(vals)-1] {
+	return vals[len(vals)-1], true
+}
+
+func (t *tree) GetBool(config, section, option string) (bool, bool) {
+	val, ok := t.GetLast(config, section, option)
+	if !ok {
+		return false, false
+	}
+	switch val {
 	case "1", "on", "true", "yes", "enabled":
 		return true, true
 	case "0", "off", "false", "no", "disabled":

--- a/uci_test.go
+++ b/uci_test.go
@@ -130,6 +130,26 @@ func TestListDelete(t *testing.T) {
 	assert.Empty(val)
 }
 
+func TestGetLast_Success(t *testing.T) {
+	assert := assert.New(t)
+
+	r := NewTree("testdata")
+
+	val, ok := r.GetLast("system", "ntp", "server")
+	assert.True(ok)
+
+	assert.Equal(val, "3.lede.pool.ntp.org")
+}
+
+func TestGetLast_Failure(t *testing.T) {
+	assert := assert.New(t)
+
+	r := NewTree("testdata")
+
+	_, ok := r.GetLast("system", "ntp", "port")
+	assert.False(ok)
+}
+
 func TestGetBool_False(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
This PR introduces a new function `(Tree).Get` which allows to work around the awkwardness of checking the return value so that a call like this:

```golang
	vals, ok = r.Get("system", "ntp", "enable_server")
	if !ok || len(vals) == 0 {
		// ...
	}
	val := vals[len(vals)-1]
	// ...
```

becomes 

```golang
	val, ok = r.GetLast("system", "ntp", "enable_server")
	if !ok {
		// ...
	}
	// ...
```

Simpler, isn't it?