### PR TITLE
Stop value parsing at comment

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -346,7 +346,7 @@ Loop:
 			fallthrough
 		case eof:
 			return l.errorf("unterminated unquoted string")
-		case ' ', '#', '\n':
+		case ' ', '\t', '#', '\n':
 			break Loop
 		}
 	}

--- a/lexer.go
+++ b/lexer.go
@@ -346,7 +346,7 @@ Loop:
 			fallthrough
 		case eof:
 			return l.errorf("unterminated unquoted string")
-		case ' ', '\n':
+		case ' ', '#', '\n':
 			break Loop
 		}
 	}


### PR DESCRIPTION
A comment at the end of an unqouted value would result in a parse error.  This terminates the value at the comment symbol # to allow the comment to be ignored successfully.
