### PR TITLE
Add GetSectionOptions API and clean up lexer/staticcheck issues

### DIFF
--- a/convenience.go
+++ b/convenience.go
@@ -26,6 +26,11 @@ func GetSections(config, secType string) ([]string, error) {
 	return defaultTree.GetSections(config, secType)
 }
 
+// GetSectionOptions delegates to the default tree. See Tree for details.
+func GetSectionOptions(config, secType string) ([]SectionOption, error) {
+	return defaultTree.GetSectionOptions(config, secType)
+}
+
 // Get delegates to the default tree. See Tree for details.
 func Get(config, section, option string) ([]string, bool) {
 	return defaultTree.Get(config, section, option)

--- a/convenience.go
+++ b/convenience.go
@@ -27,8 +27,8 @@ func GetSections(config, secType string) ([]string, error) {
 }
 
 // GetSectionOptions delegates to the default tree. See Tree for details.
-func GetSectionOptions(config, secType string) ([]SectionOption, error) {
-	return defaultTree.GetSectionOptions(config, secType)
+func GetSectionOptions(config, section string) ([]SectionOption, error) {
+	return defaultTree.GetSectionOptions(config, section)
 }
 
 // Get delegates to the default tree. See Tree for details.

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -35,6 +35,14 @@ func (m *mockTree) GetSections(config string, secType string) ([]string, error) 
 	return []string{args.String(0)}, args.Error(1)
 }
 
+func (m *mockTree) GetSectionOptions(config string, section string) ([]SectionOption, error) {
+	args := m.Called(config, section)
+	return []SectionOption{{
+		Name: args.String(0),
+		Type: OptionType(args.Int(1)),
+	}}, args.Error(2)
+}
+
 func (m *mockTree) Get(config, section, option string) ([]string, bool) {
 	args := m.Called(config, section, option)
 	return []string{args.String(0)}, args.Bool(1)
@@ -108,6 +116,16 @@ func TestConvenienceGetSections(t *testing.T) {
 	list, err := GetSections("foo", "bar")
 	assert.NoError(err)
 	assert.EqualValues([]string{"sec1"}, list)
+	m.AssertExpectations(t)
+}
+
+func TestConvenienceGetSectionOptions(t *testing.T) {
+	assert := assert.New(t)
+	m := defaultTree.(*mockTree)
+	m.On("GetSectionOptions", "foo", "bar").Return("opt1", 1, nil)
+	list, err := GetSectionOptions("foo", "bar")
+	assert.NoError(err)
+	assert.EqualValues([]SectionOption{{Name: "opt1", Type: TypeList}}, list)
 	m.AssertExpectations(t)
 }
 

--- a/lexer.go
+++ b/lexer.go
@@ -171,7 +171,11 @@ func (l *lexer) acceptComment() {
 func (l *lexer) acceptIdent() {
 	for {
 		r := l.next()
-		if !(r == '-' || r == '_' || 'a' <= r && r <= 'z' || 'A' <= r && r <= 'Z' || '0' <= r && r <= '9') {
+		if r != '-' &&
+			r != '_' &&
+			(r < 'a' || r > 'z') &&
+			(r < 'A' || r > 'Z') &&
+			(r < '0' || r > '9') {
 			l.backup()
 			break
 		}
@@ -273,10 +277,10 @@ func lexConfigType(l *lexer) stateFn {
 }
 
 func lexOptionalName(l *lexer) stateFn {
-	switch r := l.next(); {
-	case r == '\n':
+	switch l.next() {
+	case '\n':
 		l.ignore()
-	case r == '"' || r == '\'':
+	case '"', '\'':
 		l.backup()
 		return lexQuoted
 	default:

--- a/types.go
+++ b/types.go
@@ -220,6 +220,15 @@ func (c *config) count(typ string) (n int) {
 	return
 }
 
+// SectionOption describes a configuration option available in a section.
+// It provides metadata about an option (name and type) without its current value.
+//
+// Use [Tree.GetSectionOptions] to list all available options for a section.
+type SectionOption struct {
+	Name string     `json:"name,omitempty"` // Option name/key
+	Type OptionType `json:"type,omitempty"` // Expected data type
+}
+
 // A section represents a group of options in UCI. It may be named or
 // unnamed. In the latter case, its synthetic name is constructed from
 // the section type and index (e.g. "@system[0]").

--- a/uci.go
+++ b/uci.go
@@ -163,6 +163,9 @@ func (t *tree) Revert(configs ...string) {
 }
 
 func (t *tree) GetSections(config string, secType string) ([]string, error) {
+	t.Lock()
+	defer t.Unlock()
+
 	cfg, err := t.ensureConfigLoaded(config)
 	if err != nil {
 		return nil, fmt.Errorf("ensureConfigLoaded: %w", err)
@@ -179,6 +182,9 @@ func (t *tree) GetSections(config string, secType string) ([]string, error) {
 }
 
 func (t *tree) GetSectionOptions(config string, section string) ([]SectionOption, error) {
+	t.Lock()
+	defer t.Unlock()
+
 	cfg, err := t.ensureConfigLoaded(config)
 	if err != nil {
 		return nil, fmt.Errorf("ensureConfigLoaded: %w", err)

--- a/uci.go
+++ b/uci.go
@@ -41,6 +41,17 @@ type Tree interface {
 	// successful.
 	GetSections(config, secType string) ([]string, error)
 
+	// GetSectionOptions returns metadata for all configuration options
+	// available in the specified section.
+	//
+	// The returned slice contains option names and their expected types,
+	// but not current values.
+	//
+	// Returns an error if:
+	//   - the config was not loaded into the tree;
+	//   - the section doesn't exist.
+	GetSectionOptions(config string, section string) ([]SectionOption, error)
+
 	// Get retrieves (all) values for a fully qualified option, and a
 	// boolean indicating whether the config file and the config section
 	// within exists.
@@ -157,7 +168,7 @@ func (t *tree) GetSections(config string, secType string) ([]string, error) {
 		return nil, fmt.Errorf("ensureConfigLoaded: %w", err)
 	}
 
-	names := []string{}
+	names := make([]string, 0, len(cfg.Sections))
 	for _, s := range cfg.Sections {
 		if s.Type == secType {
 			names = append(names, cfg.sectionName(s))
@@ -165,6 +176,28 @@ func (t *tree) GetSections(config string, secType string) ([]string, error) {
 	}
 
 	return names, nil
+}
+
+func (t *tree) GetSectionOptions(config string, section string) ([]SectionOption, error) {
+	cfg, err := t.ensureConfigLoaded(config)
+	if err != nil {
+		return nil, fmt.Errorf("ensureConfigLoaded: %w", err)
+	}
+
+	cfgSection := cfg.Get(section)
+	if cfgSection == nil {
+		return nil, ErrSectionNotFound{section}
+	}
+
+	options := make([]SectionOption, 0, len(cfgSection.Options))
+	for _, opt := range cfgSection.Options {
+		options = append(options, SectionOption{
+			Name: opt.Name,
+			Type: opt.Type,
+		})
+	}
+
+	return options, nil
 }
 
 func (t *tree) Get(config, section, option string) ([]string, bool) {
@@ -346,22 +379,22 @@ func (t *tree) saveConfig(c *config) error {
 
 	_, err = c.WriteTo(f)
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		_ = f.Remove()
 		return err
 	}
 
 	if err = f.Chmod(0o644); err != nil {
-		f.Close()
+		_ = f.Close()
 		_ = f.Remove()
 		return fmt.Errorf("save: failed to set permissions: %w", err)
 	}
 	if err = f.Sync(); err != nil {
-		f.Close()
+		_ = f.Close()
 		_ = f.Remove()
 		return fmt.Errorf("save: failed to sync: %w", err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	if err = f.Rename(filepath.Join(t.dir, c.Name)); err != nil {
 		return fmt.Errorf("save: failed to replace existing config: %w", err)
@@ -394,6 +427,6 @@ type tmpFileImpl struct{ *os.File }
 
 func (tmp *tmpFileImpl) Chmod(mode os.FileMode) error { return tmp.File.Chmod(mode) }
 func (tmp *tmpFileImpl) Close() error                 { return tmp.File.Close() }
-func (tmp *tmpFileImpl) Remove() error                { return os.Remove(tmp.File.Name()) }
-func (tmp *tmpFileImpl) Rename(newpath string) error  { return os.Rename(tmp.File.Name(), newpath) }
+func (tmp *tmpFileImpl) Remove() error                { return os.Remove(tmp.File.Name()) }          //nolint:staticcheck
+func (tmp *tmpFileImpl) Rename(newpath string) error  { return os.Rename(tmp.File.Name(), newpath) } //nolint:staticcheck
 func (tmp *tmpFileImpl) Sync() error                  { return tmp.File.Sync() }

--- a/uci_test.go
+++ b/uci_test.go
@@ -22,7 +22,9 @@ func loadExpected(t *testing.T, name string) *config {
 	if err != nil {
 		t.Fatalf("cannot open %s.json: %v", name, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	expected := &config{}
 	err = json.NewDecoder(f).Decode(&expected)
@@ -159,6 +161,37 @@ func TestGetSections(t *testing.T) {
 	names, err = r.GetSections("anonymous", "anon3")
 	assert.NoError(err)
 	assert.ElementsMatch(names, []string{"@anon3[0]", "@anon3[1]", "@anon3[2]"})
+}
+
+func TestGetSectionOptions(t *testing.T) {
+	assert := assert.New(t)
+
+	r := NewTree("testdata")
+
+	options, err := r.GetSectionOptions("ucitrack", "@firewall[0]")
+	assert.NoError(err)
+	assert.ElementsMatch(options, []SectionOption{
+		{
+			Name: "init",
+			Type: TypeOption,
+		},
+		{
+			Name: "affects",
+			Type: TypeList,
+		},
+	})
+
+	options, err = r.GetSectionOptions("anonymous", "@firewall[0]")
+	assert.ErrorAs(err, &ErrSectionNotFound{})
+	assert.Len(options, 0)
+
+	options, err = r.GetSectionOptions("anonymous", "@anon1[0]")
+	assert.NoError(err)
+	assert.Len(options, 0)
+
+	options, err = r.GetSectionOptions("nonexistent", "@foo[0]")
+	assert.ErrorIs(err, os.ErrNotExist) // fails as the underlying file fails to load.
+	assert.Nil(options)
 }
 
 func TestAddSection(t *testing.T) {
@@ -401,7 +434,7 @@ func TestCommit(t *testing.T) {
 
 	// try saving, but let it fail at different points
 	reset := func(onwrite, onchmod, onsync, onrename error) {
-		m.Buffer.Reset()
+		m.Buffer.Reset() //nolint:staticcheck
 		m.ExpectedCalls = nil
 		m.On("Close").Return(nil)
 		m.On("Remove").Return(nil)
@@ -413,7 +446,7 @@ func TestCommit(t *testing.T) {
 
 	reset(errors.New("fail write"), nil, nil, nil) //nolint:goerr113
 	assert.EqualError(r.Commit(), "fail write")
-	assert.Equal(0, m.Buffer.Len())
+	assert.Equal(0, m.Buffer.Len()) //nolint:staticcheck
 
 	reset(nil, errors.New("fail chmod"), nil, nil) //nolint:goerr113
 	assert.EqualError(r.Commit(), "save: failed to set permissions: fail chmod")


### PR DESCRIPTION
 - Add GetSectionOptions API to list option metadata (name and type) for a section.
- Introduce SectionOption type and convenience wrapper.
- Implement tree-level support and comprehensive tests.
- Refactor lexer condition using De Morgan’s law without changing ASCII semantics.
- Minor cleanups: preallocate slices, handle Close() errors explicitly, and address staticcheck warnings.