### PR TITLE
Added clean API for creating anonymous sections

### DIFF
--- a/convenience_test.go
+++ b/convenience_test.go
@@ -65,6 +65,11 @@ func (m *mockTree) AddSection(config, section, typ string) error {
 	return args.Error(0)
 }
 
+func (m *mockTree) AddAnonymousSection(config, typ string) error {
+	args := m.Called(config, typ)
+	return args.Error(0)
+}
+
 func (m *mockTree) DelSection(config, section string) error {
 	m.Called(config, section)
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nikitagricanuk/go-uci/v2
+module github.com/nikitagricanuk/go-uci
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/digineo/go-uci/v2
+module github.com/nikitagricanuk/go-uci/v2
 
 go 1.21
 

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.1 h1:4VhoImhV/Bm0ToFkXFi8hXNXwpDRZ/ynw3amt82mzq0=
 github.com/stretchr/objx v0.5.1/go.mod h1:/iHQpkQwBD6DLUmQ4pE+s1TXdob1mORJ4/UFdrifcy0=
+github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
+github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/lexer.go
+++ b/lexer.go
@@ -94,7 +94,7 @@ func (l *lexer) emit(t itemType) {
 
 // emitString emits a string token. it removes the surrounding quotes.
 func (l *lexer) emitString(t itemType) {
-	if l.pos-1 > l.start+1 {
+	if l.pos-1 >= l.start+1 {
 		l.items <- item{t, l.input[l.start+1 : l.pos-1], l.pos}
 		l.start = l.pos
 	}

--- a/test_test.go
+++ b/test_test.go
@@ -122,6 +122,12 @@ config foo
 	option opt opt\
 `
 
+const tcEmptyStringOption = `config foo 'bar'
+	option nonempty 'value'
+	option empty ''
+	option after_empty 'here'
+`
+
 var lexerTests = []struct {
 	name, input string
 	expected    []item
@@ -191,6 +197,12 @@ var lexerTests = []struct {
 	{"unterminated unquoted string", tcUnterminatedUnquoted, []item{
 		itemConfig.mk("config"), itemIdent.mk("foo"), // unnamed
 		itemOption.mk("option"), itemIdent.mk("opt"), itemError.mk("unterminated unquoted string"),
+	}},
+	{"empty string option", tcEmptyStringOption, []item{
+		itemConfig.mk("config"), itemIdent.mk("foo"), itemString.mk("bar"),
+		itemOption.mk("option"), itemIdent.mk("nonempty"), itemString.mk("value"),
+		itemOption.mk("option"), itemIdent.mk("empty"), itemString.mk(""),
+		itemOption.mk("option"), itemIdent.mk("after_empty"), itemString.mk("here"),
 	}},
 }
 
@@ -263,5 +275,11 @@ var parserTests = []struct {
 	{"unterminated unquoted string", tcUnterminatedUnquoted, []token{
 		tokSection.mk(itemIdent.mk("foo")),
 		tokError.mk(itemError.mk("unterminated unquoted string")),
+	}},
+	{"empty string option", tcEmptyStringOption, []token{
+		tokSection.mk(itemIdent.mk("foo"), itemString.mk("bar")),
+		tokOption.mk(itemIdent.mk("nonempty"), itemString.mk("value")),
+		tokOption.mk(itemIdent.mk("empty"), itemString.mk("")),
+		tokOption.mk(itemIdent.mk("after_empty"), itemString.mk("here")),
 	}},
 }

--- a/types.go
+++ b/types.go
@@ -181,14 +181,22 @@ func (c *config) Merge(s *section) *section {
 }
 
 func (c *config) Del(name string) {
-	var i int
-	for i = 0; i < len(c.Sections); i++ {
-		if c.Sections[i].Name == name {
-			break
-		}
+	// Resolve the section to a pointer, handling both named sections and the
+	// anonymous "@type[index]" selector syntax.
+	var target *section
+	if strings.HasPrefix(name, "@") {
+		target, _ = c.getUnnamed(name)
+	} else {
+		target = c.getNamed(name)
 	}
-	if i < len(c.Sections) {
-		c.Sections = append(c.Sections[:i], c.Sections[i+1:]...)
+	if target == nil {
+		return
+	}
+	for i, s := range c.Sections {
+		if s == target {
+			c.Sections = append(c.Sections[:i], c.Sections[i+1:]...)
+			return
+		}
 	}
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -49,6 +49,125 @@ func TestUnmangleSectionName(t *testing.T) {
 	}
 }
 
+func TestConfigDel_Named(t *testing.T) {
+	assert := assert.New(t)
+	c := newConfig("test")
+	// newSection signature: newSection(typ, name)
+	c.Sections = append(c.Sections, newSection("peer", "alice"), newSection("peer", "bob"))
+
+	c.Del("alice")
+
+	assert.Len(c.Sections, 1)
+	assert.Equal("bob", c.Sections[0].Name)
+}
+
+func TestConfigDel_Anonymous(t *testing.T) {
+	// Del must remove an anonymous section when addressed via "@type[index]".
+	assert := assert.New(t)
+	c := newConfig("test")
+	c.Sections = append(c.Sections,
+		newSection("peer", ""),
+		newSection("peer", ""),
+		newSection("peer", ""),
+	)
+
+	c.Del("@peer[1]")
+
+	assert.Len(c.Sections, 2, "one section should be gone")
+	// The remaining sections must still be reachable as @peer[0] and @peer[1].
+	assert.NotNil(c.Get("@peer[0]"))
+	assert.NotNil(c.Get("@peer[1]"))
+	// Three sections → only two must remain.
+	assert.Nil(c.Get("@peer[2]"))
+}
+
+func TestConfigDel_AnonymousFirst(t *testing.T) {
+	// Deleting the first anonymous section must shift the indices of the
+	// remaining ones, not leave gaps.
+	assert := assert.New(t)
+	c := newConfig("test")
+	s0 := newSection("peer", "")
+	s1 := newSection("peer", "")
+	s2 := newSection("peer", "")
+	// Give each section a distinguishing option so we can tell them apart.
+	s0.Options = []*option{newOption("id", TypeOption, "0")}
+	s1.Options = []*option{newOption("id", TypeOption, "1")}
+	s2.Options = []*option{newOption("id", TypeOption, "2")}
+	c.Sections = append(c.Sections, s0, s1, s2)
+
+	c.Del("@peer[0]")
+
+	assert.Len(c.Sections, 2)
+	// What was @peer[1] is now @peer[0].
+	got := c.Get("@peer[0]")
+	assert.NotNil(got)
+	assert.Equal("1", got.Get("id").Values[0])
+}
+
+func TestConfigDel_AnonymousLast(t *testing.T) {
+	assert := assert.New(t)
+	c := newConfig("test")
+	c.Sections = append(c.Sections,
+		newSection("peer", ""),
+		newSection("peer", ""),
+	)
+
+	c.Del("@peer[-1]") // negative index: last element
+
+	assert.Len(c.Sections, 1)
+	assert.NotNil(c.Get("@peer[0]"))
+	assert.Nil(c.Get("@peer[1]"))
+}
+
+func TestConfigDel_AnonymousOnly(t *testing.T) {
+	// Removing the sole anonymous section must leave an empty Sections slice.
+	assert := assert.New(t)
+	c := newConfig("test")
+	c.Sections = append(c.Sections, newSection("peer", ""))
+
+	c.Del("@peer[0]")
+
+	assert.Len(c.Sections, 0)
+}
+
+func TestConfigDel_NotFound(t *testing.T) {
+	// Deleting a non-existent name must be a silent no-op.
+	assert := assert.New(t)
+	c := newConfig("test")
+	c.Sections = append(c.Sections, newSection("peer", "alice"))
+
+	c.Del("bob")       // named, not present
+	c.Del("@peer[5]")  // anonymous, index out of bounds
+	c.Del("@other[0]") // anonymous, type not present
+
+	assert.Len(c.Sections, 1)
+}
+
+func TestConfigDel_MixedNamedAndAnonymous(t *testing.T) {
+	// The @type[index] selector counts ALL sections of a given type, including
+	// named ones. So with [named, anon, anon]:
+	//   @peer[0] == "named"
+	//   @peer[1] == first anonymous
+	//   @peer[2] == second anonymous
+	// Deleting @peer[1] removes the first anonymous section; "named" and the
+	// second anonymous section must survive.
+	assert := assert.New(t)
+	c := newConfig("test")
+	c.Sections = append(c.Sections,
+		newSection("peer", "named"),
+		newSection("peer", ""),
+		newSection("peer", ""),
+	)
+
+	c.Del("@peer[1]") // first anonymous section
+
+	assert.Len(c.Sections, 2)
+	assert.NotNil(c.Get("named"))
+	// The second anonymous section is now the only one and sits at @peer[1]
+	// (index 0 is still occupied by "named").
+	assert.NotNil(c.Get("@peer[1]"))
+}
+
 func TestConfigGet(t *testing.T) { //nolint:funlen
 	config, err := parse("unnamed", tcUnnamedInput)
 	assert.NoError(t, err)

--- a/uci.go
+++ b/uci.go
@@ -70,6 +70,9 @@ type Tree interface {
 	// Otherwise an ErrSectionTypeMismatch is returned.
 	AddSection(config, section, typ string) error
 
+	// AddAnonymousSection adds a new anonymous section.
+	AddAnonymousSection(config, typ string) error
+
 	// DelSection remove a config section and its options.
 	DelSection(config, section string) error
 }
@@ -283,23 +286,33 @@ func (t *tree) Del(config, section, option string) error {
 	return nil
 }
 
-func (t *tree) AddSection(config, section, typ string) error {
-	t.Lock()
-	defer t.Unlock()
-
-	cfg, err := t.ensureConfigLoaded(config)
+// getOrCreateConfig loads the named config, or creates a new empty one if the
+// file doesn't exist yet. Must be called with t.Lock held.
+func (t *tree) getOrCreateConfig(name string) (*config, error) {
+	cfg, err := t.ensureConfigLoaded(name)
 	if err != nil {
 		if errors.Is(err, ParseError{}) {
-			return fmt.Errorf("ensureConfigLoaded: %w", err)
+			return nil, fmt.Errorf("ensureConfigLoaded: %w", err)
 		}
 		if errors.Is(err, os.ErrNotExist) {
 			// we want to add a section, but it failed to load. If this is a file not found error, we can
 			// just create a new config and add the section to it.
 			// if it is a parse error we want to return that error
-			cfg = newConfig(config)
+			cfg = newConfig(name)
 			cfg.tainted = true
-			t.configs[config] = cfg
+			t.configs[name] = cfg
 		}
+	}
+	return cfg, nil
+}
+
+func (t *tree) AddSection(config, section, typ string) error {
+	t.Lock()
+	defer t.Unlock()
+
+	cfg, err := t.getOrCreateConfig(config)
+	if err != nil {
+		return err
 	}
 	sec := cfg.Get(section)
 	if sec == nil {
@@ -310,6 +323,19 @@ func (t *tree) AddSection(config, section, typ string) error {
 	if sec.Type != typ {
 		return ErrSectionTypeMismatch{config, section, sec.Type, typ}
 	}
+	return nil
+}
+
+func (t *tree) AddAnonymousSection(config, typ string) error {
+	t.Lock()
+	defer t.Unlock()
+
+	cfg, err := t.getOrCreateConfig(config)
+	if err != nil {
+		return err
+	}
+	cfg.Add(newSection(typ, ""))
+	cfg.tainted = true
 	return nil
 }
 

--- a/uci_test.go
+++ b/uci_test.go
@@ -237,6 +237,65 @@ func TestDelSection(t *testing.T) {
 	assert.ErrorAs(err, &fileNotFound)
 }
 
+func TestDelSection_Anonymous(t *testing.T) {
+	assert := assert.New(t)
+	r := NewTree("testdata")
+
+	// The "anonymous" testdata file has one @anon1[0], two @anon2[*], and
+	// three @anon3[*] sections.
+	names, err := r.GetSections("anonymous", "anon3")
+	assert.NoError(err)
+	assert.Len(names, 3)
+
+	// Remove the middle anonymous section.
+	err = r.DelSection("anonymous", "@anon3[1]")
+	assert.NoError(err)
+
+	names, err = r.GetSections("anonymous", "anon3")
+	assert.NoError(err)
+	assert.Len(names, 2, "one section should have been removed")
+	assert.ElementsMatch(names, []string{"@anon3[0]", "@anon3[1]"})
+}
+
+func TestDelSection_AnonymousFirst(t *testing.T) {
+	assert := assert.New(t)
+	r := NewTree("testdata")
+
+	// Add two anonymous sections with distinct options so we can verify
+	// which one survives.
+	assert.NoError(r.AddAnonymousSection("anonymous", "newtype"))
+	assert.NoError(r.SetType("anonymous", "@newtype[0]", "id", TypeOption, "first"))
+	assert.NoError(r.AddAnonymousSection("anonymous", "newtype"))
+	assert.NoError(r.SetType("anonymous", "@newtype[1]", "id", TypeOption, "second"))
+
+	assert.NoError(r.DelSection("anonymous", "@newtype[0]"))
+
+	names, err := r.GetSections("anonymous", "newtype")
+	assert.NoError(err)
+	assert.Len(names, 1)
+
+	val, ok := r.GetLast("anonymous", "@newtype[0]", "id")
+	assert.True(ok)
+	assert.Equal("second", val, "the second section should now be at index 0")
+}
+
+func TestDelSection_AnonymousAll(t *testing.T) {
+	// Removing all anonymous sections of a type must leave none behind.
+	// Because deletion shifts indices, always re-query and delete [0] rather
+	// than iterating over a pre-captured name slice.
+	assert := assert.New(t)
+	r := NewTree("testdata")
+
+	n, _ := r.GetSections("anonymous", "anon2")
+	for range n {
+		assert.NoError(r.DelSection("anonymous", "@anon2[0]"))
+	}
+
+	remaining, err := r.GetSections("anonymous", "anon2")
+	assert.NoError(err)
+	assert.Len(remaining, 0)
+}
+
 func TestGet(t *testing.T) {
 	assert := assert.New(t)
 

--- a/uci_test.go
+++ b/uci_test.go
@@ -183,6 +183,35 @@ func TestAddSection(t *testing.T) {
 	assert.ElementsMatch(values, []string{"value"})
 }
 
+func TestAddAnonymousSection(t *testing.T) {
+	assert := assert.New(t)
+	r := NewTree("testdata")
+
+	assert.NoError(r.AddAnonymousSection("anonymous", "anon1"))
+	names, err := r.GetSections("anonymous", "anon1")
+	assert.NoError(err)
+	assert.Len(names, 2)
+	assert.ElementsMatch(names, []string{"@anon1[0]", "@anon1[1]"})
+
+	assert.NoError(r.AddAnonymousSection("anonymous", "anon2"))
+	assert.NoError(r.AddAnonymousSection("anonymous", "anon2"))
+	names, err = r.GetSections("anonymous", "anon2")
+	assert.NoError(err)
+	assert.Len(names, 4)
+
+	assert.NoError(r.AddAnonymousSection("anonymous", "newtype"))
+	assert.NoError(r.SetType("anonymous", "@newtype[0]", "key", TypeOption, "val"))
+	values, exists := r.Get("anonymous", "@newtype[0]", "key")
+	assert.True(exists)
+	assert.ElementsMatch(values, []string{"val"})
+
+	assert.NoError(r.AddAnonymousSection("nonexistent", "newtype"))
+	assert.NoError(r.SetType("nonexistent", "@newtype[0]", "key", TypeOption, "val"))
+	values, exists = r.Get("nonexistent", "@newtype[0]", "key")
+	assert.True(exists)
+	assert.ElementsMatch(values, []string{"val"})
+}
+
 func TestDelSection(t *testing.T) {
 	assert := assert.New(t)
 	r := NewTree("testdata")
@@ -205,8 +234,7 @@ func TestDelSection(t *testing.T) {
 	assert.Error(err)
 	assert.True(errors.As(err, &fileNotFound))
 	_, err = r.GetSections("nonexistent", "foo")
-	assert.Error(err) // Todo: specify error type
-	assert.True(errors.As(err, &fileNotFound))
+	assert.ErrorAs(err, &fileNotFound)
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
I've noticed that the library lacked clean API for creating anonymous sections in uci. The only way to create such section is to set section name to empty string, but this behaviour isn't documented and hasn't been tested. I've added new AddAnonymousSection function that does this and added some tests for it. 