### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 UCI is OpenWrt's [Unified Configuration Interface][uci-wiki]. It is
 used to configure OpenWrt router hardware using a simple DSL (and
-acompanying CLI tools). Configuration files are written into a
+accompanying CLI tools). Configuration files are written into a
 central directory (`/etc/config/*`) which basically represents a
 key/value store.
 
@@ -60,7 +60,7 @@ import "github.com/digineo/go-uci"
 func main() {
     // use the default tree (/etc/config)
     if values, ok := uci.Get("system", "@system[0]", "hostname"); ok {
-        fmt.Println("hostanme", values)
+        fmt.Println("hostname", values)
         //=> hostname [OpenWrt]
     }
 

--- a/parser.go
+++ b/parser.go
@@ -13,7 +13,7 @@ import (
 type scanner struct {
 	lexer  *lexer
 	state  scanFn
-	last   *item  // last item read from the lexer, but deffered by the state
+	last   *item  // last item read from the lexer, but deferred by the state
 	curr   []item // accepted items
 	tokens chan token
 }


### PR DESCRIPTION
Found via `codespell -L ot,ket`