### PR TITLE
Fix: do not deduplicate list items when reading from uci

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -264,7 +264,7 @@ func parse(name, input string) (cfg *config, err error) {
 			val := tok.items[1].val
 
 			if opt := sec.Get(name); opt != nil {
-				opt.MergeValues(val)
+				opt.AddValue(val)
 			} else {
 				sec.Add(newOption(name, TypeList, val))
 			}


### PR DESCRIPTION
The current implementation deduplicates list items when reading, e.g. with a uci configuration like

``` uci
config task x 
    list cmd '--user'
    list cmd 'foo'
    list cmd '--default'
    list cmd 'foo'
```

uci.Get returns the list as just `['--user', 'foo', '--default']`. AddValue seems to have the correct behaviour, but I don't know if this maybe breaks a defined behaviour elsewhere?